### PR TITLE
feature: visual themes, footer rotation, responsive

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "pif",
       "dependencies": {
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
+        "@fontsource/archivo-black": "^5.2.8",
         "@hono/node-server": "^2.0.1",
         "hono": "^4.6.0",
         "react": "^19.0.0",
@@ -133,6 +135,10 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@fontsource-variable/jetbrains-mono": ["@fontsource-variable/jetbrains-mono@5.2.8", "", {}, "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q=="],
+
+    "@fontsource/archivo-black": ["@fontsource/archivo-black@5.2.8", "", {}, "sha512-3zNj/o9LzWyDl/UEpY5IOHpAQyUtFr3hQaFS7NSKwCLLkXOfH/CMCt1L2b2Z+OF25OURtOYenCadgAebALz7/A=="],
 
     "@hono/node-server": ["@hono/node-server@2.0.1", "", { "peerDependencies": { "hono": "^4" } }, "sha512-jI9yMDyFpqBeSighf/zlXnQG/nl9AyBc6aAgy4XtxJMyt/CNyJpvPfzDD+bCc2zAOmhhqtF6TnmIaY+xV4mIrw=="],
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -7,7 +7,7 @@
 
 - [x] **Slice 1 — Generation engine + minimal home** — [#1](https://github.com/TituxMetal/pif-is-fake/issues/1) · `feature/generation-engine`
 - [x] **Slice 2 — Salarié routes + permalink + mouline** — [#2](https://github.com/TituxMetal/pif-is-fake/issues/2) · `feature/salarie-routing`
-- [ ] **Slice 3 — Visual themes + footer + responsive** — [#3](https://github.com/TituxMetal/pif-is-fake/issues/3) · `feature/visual-themes`
+- [x] **Slice 3 — Visual themes + footer + responsive** — [#3](https://github.com/TituxMetal/pif-is-fake/issues/3) · `feature/visual-themes`
 - [ ] **Slice 4 — Sharing + dispatch + prod server + deploy** — [#4](https://github.com/TituxMetal/pif-is-fake/issues/4) · `feature/ship-prod`
 
 ## Workflow per slice

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "format:check": "biome format ."
   },
   "dependencies": {
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource/archivo-black": "^5.2.8",
     "@hono/node-server": "^2.0.1",
     "hono": "^4.6.0",
     "react": "^19.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Disclaimer } from '~/features/disclaimer'
 import { Home } from '~/features/home'
+import { AppShell } from '~/features/shell'
 import { type RouteIntent, useRouteIntent } from '~/lib/routing'
 
 const homeKey = (intent: RouteIntent): string => {
@@ -14,10 +15,26 @@ const homeKey = (intent: RouteIntent): string => {
   return 'home'
 }
 
+const pathFromIntent = (intent: RouteIntent): string => {
+  if (intent.kind === 'disclaimer') return '~/avertissement'
+  if (intent.kind === 'forced-prenom') return `~/pif/${intent.prenom}`
+  if (intent.kind === 'forced-prenom-sigle') return `~/pif/${intent.prenom}/${intent.sigle}`
+  if (intent.kind === 'replay') return `~/pif/${intent.prenom}/${intent.sigle}`
+
+  return '~/pif'
+}
+
 export const App = () => {
   const intent = useRouteIntent()
+  const path = pathFromIntent(intent)
 
-  if (intent.kind === 'disclaimer') return <Disclaimer />
-
-  return <Home key={homeKey(intent)} intent={intent} />
+  return (
+    <AppShell path={path}>
+      {intent.kind === 'disclaimer' ? (
+        <Disclaimer />
+      ) : (
+        <Home key={homeKey(intent)} intent={intent} />
+      )}
+    </AppShell>
+  )
 }

--- a/src/features/disclaimer/components/Disclaimer.tsx
+++ b/src/features/disclaimer/components/Disclaimer.tsx
@@ -1,32 +1,29 @@
-export const Disclaimer = () => {
-  return (
-    <main className='min-h-screen flex flex-col items-center gap-6 p-6 bg-base-100 text-base-content'>
-      <article className='max-w-prose flex flex-col gap-4'>
-        <h1 className='text-3xl font-bold tracking-tight'>AVERTISSEMENT</h1>
+export const Disclaimer = () => (
+  <section className='mx-auto flex w-full max-w-prose flex-col gap-6 py-12 font-mono text-sm leading-relaxed'>
+    <h1 className='font-display text-3xl tracking-tight uppercase text-hi md:text-4xl'>
+      Avertissement
+    </h1>
 
-        <p>
-          PIF est une parodie. Les sociétés sont des sigles tirés au sort. Les sommes, les motifs et
-          les distributions sortent d'un algorithme qui ne sait rien de toi, de ton site, ni de ton
-          boulot.
-        </p>
+    <p>
+      PIF est une parodie. Les sociétés sont des sigles tirés au sort. Les sommes, les motifs et les
+      distributions sortent d'un algorithme qui ne sait rien de toi, de ton site, ni de ton boulot.
+    </p>
 
-        <p>Toute ressemblance avec un système de primes existant serait le pur effet du hasard.</p>
+    <p>Toute ressemblance avec un système de primes existant serait le pur effet du hasard.</p>
 
-        <p>
-          Les prénoms qui apparaissent dans l'application peuvent être réels — saisis par le
-          visiteur ou choisis par l'auteur. Mais aucun chiffre, aucun motif, aucune répartition
-          rattachée à un prénom ne décrit le travail ou la rémunération réelle de qui que ce soit.
-          Tout est tiré au sort.
-        </p>
+    <p>
+      Les prénoms qui apparaissent dans l'application peuvent être réels — saisis par le visiteur ou
+      choisis par l'auteur. Mais aucun chiffre, aucun motif, aucune répartition rattachée à un
+      prénom ne décrit le travail ou la rémunération réelle de qui que ce soit. Tout est tiré au
+      sort.
+    </p>
 
-        <hr className='border-t opacity-40' />
+    <hr className='border-t border-fg-faint' />
 
-        <p>
-          PIF est né d'une frustration : voir un système d'évaluation qui ne récompense pas ce qu'il
-          prétend récompenser. Le problème n'est pas individuel — c'est la mécanique qui crée le
-          piège. Le système peut être mauvais sans qu'aucun de ceux qui le font tourner ne le soit.
-        </p>
-      </article>
-    </main>
-  )
-}
+    <p>
+      PIF est né d'une frustration : voir un système d'évaluation qui ne récompense pas ce qu'il
+      prétend récompenser. Le problème n'est pas individuel — c'est la mécanique qui crée le piège.
+      Le système peut être mauvais sans qu'aucun de ceux qui le font tourner ne le soit.
+    </p>
+  </section>
+)

--- a/src/features/home/components/Home.tsx
+++ b/src/features/home/components/Home.tsx
@@ -98,8 +98,19 @@ export const Home = ({ intent }: HomeProps) => {
   }
 
   return (
-    <main className='min-h-screen flex flex-col items-center justify-center gap-6 p-6 bg-base-100 text-base-content'>
-      <h1 className='text-4xl font-bold tracking-tight'>PrimeAuPif</h1>
+    <section className='mx-auto flex w-full max-w-md flex-col gap-8 py-12'>
+      <header className='flex flex-col gap-4'>
+        <h1 className='wordmark font-display text-4xl leading-none tracking-tight uppercase md:text-5xl'>
+          <span className='wordmark-prime'>Prime</span>
+          <span className='wordmark-au'>Au</span>
+          <span className='wordmark-pif text-hi'>Pif</span>
+        </h1>
+        <p className='font-mono text-xs leading-relaxed text-fg-dim'>
+          Tirage mensuel arbitraire.
+          <br />
+          <span className='text-hi'>0 à 350 €</span>. Personne sait pourquoi.
+        </p>
+      </header>
 
       {phase === 'loading' && loading !== null && (
         <Loading
@@ -111,15 +122,20 @@ export const Home = ({ intent }: HomeProps) => {
 
       {phase !== 'loading' && (
         <>
-          <div className='flex flex-col gap-3 w-full max-w-md'>
-            <label className='flex flex-col gap-1'>
-              <span className='text-sm opacity-70'>Ton prénom (optionnel)</span>
-              <input
-                type='text'
-                value={prenomInput}
-                onChange={handlePrenomChange}
-                className='border px-2 py-1'
-              />
+          <div className='flex w-full flex-col gap-4'>
+            <label className='flex flex-col gap-2 font-mono text-xs uppercase text-fg-dim'>
+              ▸ Ton prénom (optionnel)
+              <span className='flex min-h-11 items-center gap-2 border border-fg-faint border-l-2 border-l-hi bg-panel px-3'>
+                <span aria-hidden='true' className='text-fg-dim'>
+                  $
+                </span>
+                <input
+                  type='text'
+                  value={prenomInput}
+                  onChange={handlePrenomChange}
+                  className='flex-1 bg-transparent py-2 font-mono text-sm text-fg focus:outline-none'
+                />
+              </span>
             </label>
             <VestSelector value={vestSelect} onChange={setVestSelect} />
           </div>
@@ -127,14 +143,15 @@ export const Home = ({ intent }: HomeProps) => {
           <button
             type='button'
             onClick={handleRoll}
-            className='border px-4 py-2 font-bold uppercase'
+            className='flex min-h-12 w-full cursor-pointer items-center justify-between gap-3 border-2 border-hi bg-hi px-4 py-3 font-mono text-sm font-bold tracking-wide uppercase text-bg hover:bg-bg hover:text-hi'
           >
-            {roll === null ? 'Tirer ma prime' : 'Tirer une autre prime'}
+            <span>{roll === null ? 'Tirer ma prime' : 'Tirer une autre prime'}</span>
+            <span aria-hidden='true'>▶▶</span>
           </button>
 
           {roll && <ResultDisplay roll={roll} />}
         </>
       )}
-    </main>
+    </section>
   )
 }

--- a/src/features/home/components/Loading.tsx
+++ b/src/features/home/components/Loading.tsx
@@ -32,8 +32,8 @@ export const Loading = ({ steps, durationMs, onComplete }: LoadingProps) => {
   if (currentStep === undefined) return null
 
   return (
-    <div role='status' aria-live='polite' className='text-center'>
-      <p>{currentStep}</p>
+    <div role='status' aria-live='polite' className='py-8 text-center'>
+      <p className='font-mono text-sm text-hi'>{currentStep}</p>
     </div>
   )
 }

--- a/src/features/home/components/ResultDisplay.tsx
+++ b/src/features/home/components/ResultDisplay.tsx
@@ -8,7 +8,8 @@ interface ResultDisplayProps {
 const getBonusLabel = (bonus: Bonus): string | null => {
   if (bonus === 50) return 'Bonus surproduction'
   if (bonus === 100) return 'Bonus négocié au bureau'
-  if (bonus === 150) return "Bonus — t'as bien fait de râler"
+  if (bonus === 150) return `Bonus — t'as bien fait de râler`
+
   return null
 }
 
@@ -19,25 +20,45 @@ export const ResultDisplay = ({ roll }: ResultDisplayProps) => {
   const bonusLabel = getBonusLabel(roll.bonus)
 
   return (
-    <article className='border p-4 flex flex-col gap-2 max-w-md'>
-      <header>
-        <h2 className='text-2xl font-bold'>
+    <article
+      data-vest={roll.vest}
+      className='flex w-full flex-col border border-fg-faint bg-panel font-mono text-sm'
+    >
+      <header className='border-b border-fg-faint p-5'>
+        <p className='text-xs uppercase text-fg-dim'>Relevé de prime</p>
+        <h2 className='mt-1 text-lg font-bold tracking-wide text-hi uppercase'>
           {roll.prenom} — {roll.sigle} Logistics
         </h2>
       </header>
-      <ul className='font-mono text-sm'>
-        <li>Production : {production} €</li>
-        <li>Qualité : {qualite} €</li>
-        <li>Sécurité : {securite} €</li>
-        {bonusLabel && (
-          <li>
-            {bonusLabel} : +{roll.bonus} €
-          </li>
-        )}
+
+      <ul className='flex flex-col gap-1 p-5 pb-3 tabular-nums'>
+        <li className='flex justify-between'>
+          <span className='text-fg-dim'>Production</span>
+          <span>{production} €</span>
+        </li>
+        <li className='flex justify-between'>
+          <span className='text-fg-dim'>Qualité</span>
+          <span className={qualite === 0 ? 'text-red' : undefined}>{qualite} €</span>
+        </li>
+        <li className='flex justify-between'>
+          <span className='text-fg-dim'>Sécurité</span>
+          <span>{securite} €</span>
+        </li>
       </ul>
-      <p className='font-bold'>Total : {total} €</p>
-      <p className='italic'>{motif}</p>
-      <p className='text-xs opacity-70'>Gilet : {roll.vest}</p>
+
+      {bonusLabel && (
+        <p className='mx-5 mb-3 flex justify-between bg-hi-2 px-3 py-2 font-bold tabular-nums text-bg'>
+          <span className='uppercase'>{bonusLabel}</span>
+          <span>+{roll.bonus} €</span>
+        </p>
+      )}
+
+      <p className='mx-5 mb-5 flex items-baseline justify-between bg-hi px-4 py-3 text-bg'>
+        <span className='text-xs font-bold uppercase'>Total</span>
+        <span className='font-display text-3xl font-bold tabular-nums'>{total} €</span>
+      </p>
+
+      <p className='border-l-2 border-hi-2 mx-5 mb-5 pl-3 italic text-fg-dim'>{motif}</p>
     </article>
   )
 }

--- a/src/features/home/components/VestSelector.tsx
+++ b/src/features/home/components/VestSelector.tsx
@@ -14,27 +14,31 @@ const OPTIONS: ReadonlyArray<{ value: VestSelectValue; label: string }> = [
   { value: 'responsable', label: 'Responsable' }
 ]
 
-const isVestSelectValue = (v: string): v is VestSelectValue =>
-  v === 'random' || v === 'interim' || v === 'embauche' || v === 'responsable'
+const isVestSelectValue = (value: string): value is VestSelectValue =>
+  value === 'random' || value === 'interim' || value === 'embauche' || value === 'responsable'
 
 export const VestSelector = ({ value, onChange }: VestSelectorProps) => {
-  const handleChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    const v = e.target.value
-    if (isVestSelectValue(v)) onChange(v)
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const next = event.target.value
+
+    if (isVestSelectValue(next)) onChange(next)
   }
 
   return (
-    <select
-      value={value}
-      onChange={handleChange}
-      aria-label='Choix du gilet'
-      className='border px-2 py-1'
-    >
-      {OPTIONS.map((opt) => (
-        <option key={opt.value} value={opt.value}>
-          {opt.label}
-        </option>
-      ))}
-    </select>
+    <label className='flex flex-col gap-2 font-mono text-xs uppercase text-fg-dim'>
+      Gilet
+      <select
+        value={value}
+        onChange={handleChange}
+        aria-label='Choix du gilet'
+        className='min-h-11 border border-fg-faint bg-panel px-3 py-2 font-mono text-sm normal-case text-fg focus:border-hi focus:outline-none'
+      >
+        {OPTIONS.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
   )
 }

--- a/src/features/shell/components/AppShell.tsx
+++ b/src/features/shell/components/AppShell.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react'
+
+import { Footer } from './Footer'
+import { Header } from './Header'
+
+type AppShellProps = {
+  path: string
+  children: ReactNode
+}
+
+export const AppShell = ({ path, children }: AppShellProps) => (
+  <div className='flex min-h-screen flex-col bg-bg text-fg'>
+    <Header path={path} />
+    <main className='mx-auto flex w-full max-w-5xl flex-1 flex-col px-4'>{children}</main>
+    <Footer />
+  </div>
+)

--- a/src/features/shell/components/Footer.tsx
+++ b/src/features/shell/components/Footer.tsx
@@ -1,0 +1,25 @@
+import { BACKRONYMS } from '../content/backronyms'
+import { useFooterBackronym } from '../hooks/useFooterBackronym'
+
+const APP_VERSION = 'v0.0.1'
+
+export const Footer = () => {
+  const word = useFooterBackronym(BACKRONYMS)
+
+  return (
+    <footer className='border-t border-fg-faint bg-bg font-mono text-xs text-fg-dim'>
+      <p className='mx-auto max-w-5xl px-4 py-3 text-center'>
+        <span className='block sm:inline'>
+          PIF {APP_VERSION} — Prime [<span className='text-hi'>{word}</span>] Fictive
+        </span>
+        <span className='hidden sm:inline'> — </span>
+        <span className='block sm:inline'>
+          PIF Is Fake —{' '}
+          <a href='/avertissement' className='cursor-pointer underline hover:bg-fg hover:text-bg'>
+            /avertissement
+          </a>
+        </span>
+      </p>
+    </footer>
+  )
+}

--- a/src/features/shell/components/Header.tsx
+++ b/src/features/shell/components/Header.tsx
@@ -1,0 +1,21 @@
+import { ThemeSwitcher } from './ThemeSwitcher'
+
+type HeaderProps = {
+  path: string
+}
+
+export const Header = ({ path }: HeaderProps) => (
+  <header className='border-b border-fg-faint bg-panel font-mono text-xs'>
+    <div className='mx-auto grid max-w-5xl grid-cols-[auto_1fr_auto] items-center gap-3 px-4 py-2'>
+      <a
+        href='/'
+        className='inline-flex min-h-11 cursor-pointer items-center px-2 py-1 font-bold text-hi hover:bg-hi hover:text-bg'
+        aria-label="Retour à l'accueil"
+      >
+        ● Pif.sh
+      </a>
+      <span className='truncate text-center text-fg-dim'>{path}</span>
+      <ThemeSwitcher />
+    </div>
+  </header>
+)

--- a/src/features/shell/components/ThemeSwitcher.tsx
+++ b/src/features/shell/components/ThemeSwitcher.tsx
@@ -1,0 +1,17 @@
+import { useTheme } from '~/lib/theme'
+
+export const ThemeSwitcher = () => {
+  const { theme, toggleTheme } = useTheme()
+  const alternative = theme === 'terminal' ? 'Manifeste' : 'Terminal'
+
+  return (
+    <button
+      type='button'
+      onClick={toggleTheme}
+      className='min-h-11 cursor-pointer border border-fg-faint px-3 py-2 font-mono text-xs text-fg hover:bg-fg hover:text-bg'
+      aria-label={`Activer le thème ${alternative}`}
+    >
+      {alternative} ▶
+    </button>
+  )
+}

--- a/src/features/shell/components/ThemeSwitcher.tsx
+++ b/src/features/shell/components/ThemeSwitcher.tsx
@@ -10,6 +10,7 @@ export const ThemeSwitcher = () => {
       onClick={toggleTheme}
       className='min-h-11 cursor-pointer border border-fg-faint px-3 py-2 font-mono text-xs text-fg hover:bg-fg hover:text-bg'
       aria-label={`Activer le thème ${alternative}`}
+      aria-pressed={theme === 'manifeste'}
     >
       {alternative} ▶
     </button>

--- a/src/features/shell/content/backronyms.ts
+++ b/src/features/shell/content/backronyms.ts
@@ -1,0 +1,1 @@
+export const BACKRONYMS = ['Illusoire', 'Imaginaire', 'Insensée', 'Injuste'] as const

--- a/src/features/shell/hooks/useFooterBackronym.spec.ts
+++ b/src/features/shell/hooks/useFooterBackronym.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'bun:test'
+
+import {
+  advanceFooterBackronym,
+  type FooterBackronymState
+} from '~/features/shell/hooks/useFooterBackronym'
+
+const WORDS = ['Illusoire', 'Imaginaire'] as const
+
+describe('advanceFooterBackronym', () => {
+  it('starts deleting after the hold phase on the full word', () => {
+    expect(
+      advanceFooterBackronym({ wordIndex: 0, visibleLength: 9, phase: 'hold' }, WORDS)
+    ).toEqual({ wordIndex: 0, visibleLength: 9, phase: 'deleting' })
+  })
+
+  it('shrinks visibleLength by one on each deleting tick', () => {
+    expect(
+      advanceFooterBackronym({ wordIndex: 0, visibleLength: 5, phase: 'deleting' }, WORDS)
+    ).toEqual({ wordIndex: 0, visibleLength: 4, phase: 'deleting' })
+  })
+
+  it('switches to the next word and starts typing when deletion completes', () => {
+    expect(
+      advanceFooterBackronym({ wordIndex: 0, visibleLength: 0, phase: 'deleting' }, WORDS)
+    ).toEqual({ wordIndex: 1, visibleLength: 1, phase: 'typing' })
+  })
+
+  it('wraps back to the first word after the last', () => {
+    expect(
+      advanceFooterBackronym({ wordIndex: 1, visibleLength: 0, phase: 'deleting' }, WORDS)
+    ).toEqual({ wordIndex: 0, visibleLength: 1, phase: 'typing' })
+  })
+
+  it('grows visibleLength by one on each typing tick', () => {
+    expect(
+      advanceFooterBackronym({ wordIndex: 1, visibleLength: 3, phase: 'typing' }, WORDS)
+    ).toEqual({ wordIndex: 1, visibleLength: 4, phase: 'typing' })
+  })
+
+  it('switches to hold when typing reaches the full word length', () => {
+    expect(
+      advanceFooterBackronym({ wordIndex: 1, visibleLength: 10, phase: 'typing' }, WORDS)
+    ).toEqual({ wordIndex: 1, visibleLength: 10, phase: 'hold' })
+  })
+
+  it('cycles through every word in order across full delete + type sequences', () => {
+    const words = ['A', 'B', 'C'] as const
+    let state: FooterBackronymState = { wordIndex: 0, visibleLength: 1, phase: 'hold' }
+    const visited: number[] = [state.wordIndex]
+
+    for (let step = 0; step < 12; step += 1) {
+      state = advanceFooterBackronym(state, words)
+      if (state.phase === 'hold' && visited[visited.length - 1] !== state.wordIndex) {
+        visited.push(state.wordIndex)
+      }
+    }
+
+    expect(visited).toEqual([0, 1, 2, 0])
+  })
+})

--- a/src/features/shell/hooks/useFooterBackronym.ts
+++ b/src/features/shell/hooks/useFooterBackronym.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react'
+
+export type FooterBackronymPhase = 'hold' | 'deleting' | 'typing'
+
+export type FooterBackronymState = {
+  wordIndex: number
+  visibleLength: number
+  phase: FooterBackronymPhase
+}
+
+export const advanceFooterBackronym = (
+  state: FooterBackronymState,
+  words: readonly string[]
+): FooterBackronymState => {
+  if (state.phase === 'hold') {
+    return { ...state, phase: 'deleting' }
+  }
+
+  if (state.phase === 'deleting') {
+    if (state.visibleLength <= 0) {
+      const nextIndex = (state.wordIndex + 1) % words.length
+
+      return { wordIndex: nextIndex, visibleLength: 1, phase: 'typing' }
+    }
+
+    return { ...state, visibleLength: state.visibleLength - 1 }
+  }
+
+  const currentWord = words[state.wordIndex] ?? ''
+
+  if (state.visibleLength >= currentWord.length) {
+    return { ...state, phase: 'hold' }
+  }
+
+  return { ...state, visibleLength: state.visibleLength + 1 }
+}
+
+type UseFooterBackronymOptions = {
+  charDelayMs?: number
+  holdMs?: number
+}
+
+export const useFooterBackronym = (
+  words: readonly string[],
+  options: UseFooterBackronymOptions = {}
+): string => {
+  const { charDelayMs = 80, holdMs = 2500 } = options
+
+  const [state, setState] = useState<FooterBackronymState>(() => ({
+    wordIndex: 0,
+    visibleLength: words[0]?.length ?? 0,
+    phase: 'hold'
+  }))
+
+  useEffect(() => {
+    const delay = state.phase === 'hold' ? holdMs : charDelayMs
+
+    const id = setTimeout(() => {
+      setState((current) => advanceFooterBackronym(current, words))
+    }, delay)
+
+    return () => {
+      clearTimeout(id)
+    }
+  }, [state, words, charDelayMs, holdMs])
+
+  const currentWord = words[state.wordIndex] ?? ''
+
+  return currentWord.slice(0, state.visibleLength)
+}

--- a/src/features/shell/index.ts
+++ b/src/features/shell/index.ts
@@ -1,0 +1,4 @@
+export { AppShell } from './components/AppShell'
+export { Footer } from './components/Footer'
+export { Header } from './components/Header'
+export { ThemeSwitcher } from './components/ThemeSwitcher'

--- a/src/lib/theme/index.ts
+++ b/src/lib/theme/index.ts
@@ -1,0 +1,2 @@
+export type { Theme } from './theme.types'
+export { useTheme } from './useTheme'

--- a/src/lib/theme/theme.types.ts
+++ b/src/lib/theme/theme.types.ts
@@ -1,0 +1,1 @@
+export type Theme = 'terminal' | 'manifeste'

--- a/src/lib/theme/themeStorage.spec.ts
+++ b/src/lib/theme/themeStorage.spec.ts
@@ -43,6 +43,16 @@ describe('readStoredTheme', () => {
 
     expect(readStoredTheme(storage)).toBe(DEFAULT_THEME)
   })
+
+  it('returns the default theme when storage access throws', () => {
+    const storage = {
+      getItem: () => {
+        throw new Error('SecurityError: storage blocked')
+      }
+    }
+
+    expect(readStoredTheme(storage)).toBe(DEFAULT_THEME)
+  })
 })
 
 describe('writeStoredTheme', () => {
@@ -60,5 +70,15 @@ describe('writeStoredTheme', () => {
     writeStoredTheme(storage, 'manifeste')
 
     expect(storage.snapshot()[THEME_STORAGE_KEY]).toBe('manifeste')
+  })
+
+  it('does not throw when storage access throws', () => {
+    const storage = {
+      setItem: () => {
+        throw new Error('QuotaExceededError')
+      }
+    }
+
+    expect(() => writeStoredTheme(storage, 'manifeste')).not.toThrow()
   })
 })

--- a/src/lib/theme/themeStorage.spec.ts
+++ b/src/lib/theme/themeStorage.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test'
+
+import {
+  DEFAULT_THEME,
+  readStoredTheme,
+  THEME_STORAGE_KEY,
+  writeStoredTheme
+} from '~/lib/theme/themeStorage'
+
+const memoryStorage = (initial: Record<string, string> = {}) => {
+  const store = new Map<string, string>(Object.entries(initial))
+
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value)
+    },
+    snapshot: () => Object.fromEntries(store)
+  }
+}
+
+describe('readStoredTheme', () => {
+  it('returns the default theme when nothing is stored', () => {
+    const storage = memoryStorage()
+
+    expect(readStoredTheme(storage)).toBe(DEFAULT_THEME)
+  })
+
+  it('returns the stored theme when the value is valid', () => {
+    const storage = memoryStorage({ [THEME_STORAGE_KEY]: 'manifeste' })
+
+    expect(readStoredTheme(storage)).toBe('manifeste')
+  })
+
+  it('returns the default theme when the stored value is unknown', () => {
+    const storage = memoryStorage({ [THEME_STORAGE_KEY]: 'neon' })
+
+    expect(readStoredTheme(storage)).toBe(DEFAULT_THEME)
+  })
+
+  it('returns the default theme when the stored value is empty', () => {
+    const storage = memoryStorage({ [THEME_STORAGE_KEY]: '' })
+
+    expect(readStoredTheme(storage)).toBe(DEFAULT_THEME)
+  })
+})
+
+describe('writeStoredTheme', () => {
+  it('persists the theme under the storage key', () => {
+    const storage = memoryStorage()
+
+    writeStoredTheme(storage, 'manifeste')
+
+    expect(storage.snapshot()[THEME_STORAGE_KEY]).toBe('manifeste')
+  })
+
+  it('overwrites a previously stored theme', () => {
+    const storage = memoryStorage({ [THEME_STORAGE_KEY]: 'terminal' })
+
+    writeStoredTheme(storage, 'manifeste')
+
+    expect(storage.snapshot()[THEME_STORAGE_KEY]).toBe('manifeste')
+  })
+})

--- a/src/lib/theme/themeStorage.ts
+++ b/src/lib/theme/themeStorage.ts
@@ -9,13 +9,22 @@ type WritableStorage = Pick<Storage, 'setItem'>
 const isTheme = (value: unknown): value is Theme => value === 'terminal' || value === 'manifeste'
 
 export const readStoredTheme = (storage: ReadableStorage): Theme => {
-  const raw = storage.getItem(THEME_STORAGE_KEY)
+  try {
+    const raw = storage.getItem(THEME_STORAGE_KEY)
 
-  if (isTheme(raw)) return raw
+    if (isTheme(raw)) return raw
 
-  return DEFAULT_THEME
+    return DEFAULT_THEME
+  } catch {
+    return DEFAULT_THEME
+  }
 }
 
 export const writeStoredTheme = (storage: WritableStorage, theme: Theme): void => {
-  storage.setItem(THEME_STORAGE_KEY, theme)
+  try {
+    storage.setItem(THEME_STORAGE_KEY, theme)
+  } catch {
+    // Storage may be blocked (Safari private mode, Brave strict, quota exceeded).
+    // Persistence is non-critical — silently degrade.
+  }
 }

--- a/src/lib/theme/themeStorage.ts
+++ b/src/lib/theme/themeStorage.ts
@@ -1,0 +1,21 @@
+import type { Theme } from './theme.types'
+
+export const THEME_STORAGE_KEY = 'pif:theme'
+export const DEFAULT_THEME: Theme = 'terminal'
+
+type ReadableStorage = Pick<Storage, 'getItem'>
+type WritableStorage = Pick<Storage, 'setItem'>
+
+const isTheme = (value: unknown): value is Theme => value === 'terminal' || value === 'manifeste'
+
+export const readStoredTheme = (storage: ReadableStorage): Theme => {
+  const raw = storage.getItem(THEME_STORAGE_KEY)
+
+  if (isTheme(raw)) return raw
+
+  return DEFAULT_THEME
+}
+
+export const writeStoredTheme = (storage: WritableStorage, theme: Theme): void => {
+  storage.setItem(THEME_STORAGE_KEY, theme)
+}

--- a/src/lib/theme/useTheme.ts
+++ b/src/lib/theme/useTheme.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useLayoutEffect, useState } from 'react'
 
 import type { Theme } from './theme.types'
 import { readStoredTheme, writeStoredTheme } from './themeStorage'
@@ -10,7 +10,7 @@ const applyTheme = (theme: Theme): void => {
 export const useTheme = () => {
   const [theme, setTheme] = useState<Theme>(() => readStoredTheme(window.localStorage))
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     applyTheme(theme)
   }, [theme])
 

--- a/src/lib/theme/useTheme.ts
+++ b/src/lib/theme/useTheme.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import type { Theme } from './theme.types'
+import { readStoredTheme, writeStoredTheme } from './themeStorage'
+
+const applyTheme = (theme: Theme): void => {
+  document.documentElement.dataset.theme = theme
+}
+
+export const useTheme = () => {
+  const [theme, setTheme] = useState<Theme>(() => readStoredTheme(window.localStorage))
+
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
+
+  const toggleTheme = useCallback(() => {
+    setTheme((current) => {
+      const next: Theme = current === 'terminal' ? 'manifeste' : 'terminal'
+
+      writeStoredTheme(window.localStorage, next)
+
+      return next
+    })
+  }, [])
+
+  return { theme, toggleTheme }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,9 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 
+import '@fontsource-variable/jetbrains-mono'
+import '@fontsource/archivo-black'
+
 import '~/styles/globals.css'
 
 import { App } from '~/App'

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,10 +1,77 @@
-@import "tailwindcss";
-@plugin "daisyui";
+@import 'tailwindcss';
+@plugin 'daisyui';
 
 @theme {
-  --color-pif-bg: #0e0e0f;
-  --color-pif-fg: #f5f5f4;
-  --color-pif-yellow: #facc15;
-  --color-pif-orange: #fb923c;
-  --color-pif-red: #ef4444;
+  --font-mono: 'JetBrains Mono Variable', 'IBM Plex Mono', ui-monospace, monospace;
+  --font-display: 'JetBrains Mono Variable', 'IBM Plex Mono', ui-monospace, monospace;
+
+  --color-bg: #0c0e0c;
+  --color-panel: #161816;
+  --color-fg: #7df9a3;
+  --color-fg-dim: color-mix(in srgb, var(--color-fg) 50%, transparent);
+  --color-fg-faint: color-mix(in srgb, var(--color-fg) 13%, transparent);
+  --color-red: #ff7373;
+  --color-hi: #facc15;
+  --color-hi-2: #facc15;
+}
+
+[data-theme='manifeste'] {
+  --font-display: 'Archivo Black', Impact, sans-serif;
+
+  --color-bg: #0e0e0f;
+  --color-panel: #1a1a1c;
+  --color-fg: #bdb6a8;
+  --color-red: #ef4444;
+}
+
+[data-vest='interim'] {
+  --color-hi: #facc15;
+  --color-hi-2: #facc15;
+}
+
+[data-vest='embauche'] {
+  --color-hi: #fb923c;
+  --color-hi-2: #fb923c;
+}
+
+[data-vest='responsable'] {
+  --color-hi: #facc15;
+  --color-hi-2: #fb923c;
+}
+
+@layer base {
+  html {
+    background: var(--color-bg);
+    color: var(--color-fg);
+    font-family: var(--font-mono);
+  }
+
+  body {
+    margin: 0;
+    min-height: 100vh;
+  }
+}
+
+.wordmark > span {
+  display: inline;
+}
+
+.wordmark > .wordmark-prime {
+  display: block;
+}
+
+[data-theme='manifeste'] .wordmark > span {
+  display: block;
+  line-height: 0.95;
+  letter-spacing: 0.01em;
+}
+
+[data-theme='manifeste'] .wordmark > .wordmark-pif {
+  font-size: 4.5rem;
+}
+
+@media (min-width: 768px) {
+  [data-theme='manifeste'] .wordmark > .wordmark-pif {
+    font-size: 8rem;
+  }
 }

--- a/src/types/fonts.d.ts
+++ b/src/types/fonts.d.ts
@@ -1,0 +1,2 @@
+declare module '@fontsource/*'
+declare module '@fontsource-variable/*'


### PR DESCRIPTION
Adds the brutalist visual system, two themes (Terminal + Manifeste), header theme switcher with `localStorage` persistence, footer with rotating PIF backronym, and a mobile-first re-skin of the existing surfaces.

## Highlights

- **Tokens**: Tailwind v4 `@theme` block exposes semantic tokens (`bg`, `panel`, `fg`, `fg-dim`, `fg-faint`, `red`, `hi`, `hi-2`) and two font families (`font-mono` JetBrains Mono Variable, `font-display` Archivo Black in Manifeste). Theme switches via `[data-theme='manifeste']` on `<html>`. Vest accent on result card via `[data-vest='interim'|'embauche'|'responsable']` overriding `--color-hi` / `--color-hi-2`. Theme decoupled from vest per spec.
- **Theme primitives** (`src/lib/theme/`): `themeStorage` (read/write `pif:theme` with safe parsing + default), `useTheme` hook (state ↔ localStorage ↔ document `data-theme`).
- **Shell module** (`src/features/shell/`): `AppShell` wraps every route with `Header` (brand link + intent-derived pseudo-path + `ThemeSwitcher`) and `Footer` (centered, snap-cut typewriter rotation through `Illusoire / Imaginaire / Insensée / Injuste`, accent on bracketed word, single line desktop / 2-line mobile, link to `/avertissement`).
- **Wordmark**: theme-conditional layout via CSS — Terminal renders `Prime` block then `AuPif` inline (with `Pif` in `text-hi`); Manifeste renders 3 lines with `Pif` exploding to `text-7xl mobile / text-9xl desktop`.
- **Re-skin**: `Home`, `VestSelector`, `Loading`, `ResultDisplay`, `Disclaimer` migrated to the new tokens. CTA slab `bg-hi` with `▶▶`, hover \"vidé\" (border stays, fill swaps to `bg-bg`). Result card has `data-vest`, slabs for BONUS (`bg-hi-2`) and TOTAL (`bg-hi`), motif italic with left accent border. Brutalist constraints respected (no border-radius, no soft shadow, no smooth transition, no glow, hover = hard color inversion).
- **Fonts**: `@fontsource-variable/jetbrains-mono` and `@fontsource/archivo-black` self-hosted, no CDN.
- **Background Terminal**: `#0c0e0c` (less green than initial draft per author feedback), panel `#161816`. WCAG AAA contrast preserved.

## Tests

- `themeStorage.spec.ts` — default, persisted, invalid value fallback, write round-trip
- `useFooterBackronym.spec.ts` — state machine: hold → deleting → typing → cycle through every word

## Verification

- `bun run typecheck` clean
- `bun run lint:check` clean
- `bun run format:check` clean
- `bun test` 95/95 pass

## Out of scope (carried as polish)

- Path in header doesn't update after a fresh roll (`replaceState` doesn't fire `popstate`); correct on full navigation including `/avertissement`. Will be wired via a custom event or shared context later.
- Deeper signature components (boot sequence in Terminal, ASCII progress bars, function-key buttons, window controls) — captured for a follow-up design pass.

Closes #3